### PR TITLE
feat: add tool item support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Python Library that allows you to create Fabric Minecraft mods in Python! Write 
 
 ## Features
 
-✨ **Easy Mod Creation**: Define items, blocks, and food with simple Python classes  
+✨ **Easy Mod Creation**: Define items, tools, blocks, and food with simple Python classes
 🔧 **Full Fabric Integration**: Generates complete mod projects compatible with Fabric Loader  
 🧪 **Built-in Testing**: Automatically generates unit tests and game tests  
 🎨 **Custom Creative Tabs**: Create your own creative inventory tabs  
@@ -71,6 +71,19 @@ item = fabricpy.Item(
 )
 mod.registerItem(item)
 
+# Create a tool
+pickaxe = fabricpy.ToolItem(
+    id="mymod:ruby_pickaxe",
+    name="Ruby Pickaxe",
+    durability=500,
+    mining_speed_multiplier=8.0,
+    attack_damage=3.0,
+    mining_level=2,
+    enchantability=22,
+    repair_ingredient="minecraft:ruby"
+)
+mod.registerItem(pickaxe)
+
 # Create a food item
 apple = fabricpy.FoodItem(
     id="mymod:golden_apple",
@@ -93,6 +106,11 @@ mod.registerBlock(block)
 mod.compile()
 mod.run()
 ```
+
+## Examples
+
+Additional example scripts can be found in the [`examples`](examples/) directory.
+- `tool_item.py` demonstrates defining and registering a custom `ToolItem`.
 
 ## Advanced Features
 

--- a/docs/fabricpy.rst
+++ b/docs/fabricpy.rst
@@ -38,6 +38,14 @@ fabricpy.block module
    :show-inheritance:
    :undoc-members:
 
+fabricpy.toolitem module
+------------------------
+
+.. automodule:: fabricpy.toolitem
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
 fabricpy.itemgroup module
 -------------------------
 

--- a/docs/guides/creating-items.rst
+++ b/docs/guides/creating-items.rst
@@ -19,6 +19,28 @@ Here's how to create a simple item:
        item_group=fabricpy.item_group.INGREDIENTS
    )
 
+Tool Item Creation
+------------------
+
+To create tools with durability, mining speed, and combat attributes,
+use the :class:`fabricpy.ToolItem` class:
+
+.. code-block:: python
+
+   pickaxe = fabricpy.ToolItem(
+       id="mymod:obsidian_pickaxe",
+       name="Obsidian Pickaxe",
+       durability=500,
+       mining_speed_multiplier=8.0,
+       attack_damage=3.0,
+       mining_level=2,
+       enchantability=15,
+       repair_ingredient="minecraft:obsidian",
+       item_group=fabricpy.item_group.TOOLS,
+   )
+
+See ``examples/tool_item.py`` for a complete ToolItem example.
+
 Required Parameters
 ~~~~~~~~~~~~~~~~~~~
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ fabricpy is a lightweight helper library for writing Fabric mods in Python. It p
 Features
 --------
 
-* **Item Registration**: Easy creation of custom items and food items
+* **Item Registration**: Easy creation of custom items, tools, and food items
 * **Block Registration**: Simple block creation with automatic BlockItem generation  
 * **Recipe Support**: Built-in recipe JSON handling for crafting, smelting, etc.
 * **Creative Tabs**: Support for both vanilla and custom creative inventory tabs
@@ -52,6 +52,11 @@ Helpful Tools
 -------------
 
 * `Crafting Recipe Generator <https://crafting.thedestruc7i0n.ca/>`_ - Visual interface for creating crafting recipe JSON files
+
+Examples
+--------
+
+The ``examples`` directory contains runnable scripts showcasing fabricpy features, including a ToolItem demonstration.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -72,6 +72,19 @@ Here's a complete example of creating a simple mod:
        item_group=fabricpy.item_group.INGREDIENTS
    )
 
+   # Create a tool item
+   ruby_pickaxe = fabricpy.ToolItem(
+       id="tutorial_mod:ruby_pickaxe",
+       name="Ruby Pickaxe",
+       durability=500,
+       mining_speed_multiplier=8.0,
+       attack_damage=3.0,
+       mining_level=2,
+       enchantability=22,
+       repair_ingredient="tutorial_mod:ruby",
+       item_group=fabricpy.item_group.TOOLS,
+   )
+
    # Create a food item
    ruby_apple = fabricpy.FoodItem(
        id="tutorial_mod:ruby_apple",
@@ -90,6 +103,7 @@ Here's a complete example of creating a simple mod:
 
    # Register all items and blocks
    mod.registerItem(ruby)
+   mod.registerItem(ruby_pickaxe)
    mod.registerFoodItem(ruby_apple)
    mod.registerBlock(ruby_block)
 
@@ -104,3 +118,12 @@ Next Steps
 - Use the `Crafting Recipe Generator <https://crafting.thedestruc7i0n.ca/>`_ to easily create crafting recipe JSON files with a visual interface
 - Understand custom creative tabs (see the ItemGroup class in the API reference)
 - Explore the :doc:`complete API reference <api>`
+
+Examples
+--------
+
+Example scripts can be found in the ``examples`` directory.
+
+.. literalinclude:: ../examples/tool_item.py
+   :caption: Defining a custom ToolItem
+   :language: python

--- a/examples/tool_item.py
+++ b/examples/tool_item.py
@@ -1,0 +1,28 @@
+"""Minimal example demonstrating a ToolItem."""
+
+import fabricpy
+
+# Configure the mod
+mod = fabricpy.ModConfig(
+    mod_id="example_tools",
+    name="Example Tools",
+    version="1.0.0",
+    description="Demonstrates ToolItem usage",
+    authors=["Example Dev"],
+)
+
+# Define a ruby pickaxe tool
+ruby_pickaxe = fabricpy.ToolItem(
+    id="example_tools:ruby_pickaxe",
+    name="Ruby Pickaxe",
+    durability=500,
+    mining_speed_multiplier=8.0,
+    attack_damage=3.0,
+    mining_level=2,
+    enchantability=22,
+    repair_ingredient="minecraft:ruby",
+    item_group=fabricpy.item_group.TOOLS,
+)
+
+# Register the tool with the mod
+mod.registerItem(ruby_pickaxe)

--- a/fabricpy/__init__.py
+++ b/fabricpy/__init__.py
@@ -48,6 +48,7 @@ from .__version__ import __version__
 from .block import Block
 from .fooditem import FoodItem
 from .item import Item
+from .toolitem import ToolItem
 from .itemgroup import ItemGroup
 from .modconfig import ModConfig
 from .recipejson import RecipeJson  # ← NEW import
@@ -56,6 +57,7 @@ __all__ = [
     "ModConfig",
     "Item",
     "FoodItem",
+    "ToolItem",
     "Block",
     "ItemGroup",
     "RecipeJson",  # ← expose

--- a/fabricpy/modconfig.py
+++ b/fabricpy/modconfig.py
@@ -742,13 +742,12 @@ public class CustomItem extends Item {{
 
 import net.minecraft.block.BlockState;
 import net.minecraft.component.type.AttributeModifiersComponent;
-import net.minecraft.entity.attribute.AttributeModifierSlot;
+import net.minecraft.component.type.AttributeModifierSlot;
 import net.minecraft.entity.attribute.EntityAttribute;
 import net.minecraft.entity.attribute.EntityAttributeModifier;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
-import net.minecraft.recipe.Ingredient;
 import net.minecraft.registry.Registries;
 import net.minecraft.util.Identifier;
 
@@ -760,17 +759,16 @@ public class CustomToolItem extends Item {{
     public CustomToolItem(int durability, float miningSpeedMultiplier, float attackDamage,
             int miningLevel, int enchantability, String repairIngredientId,
             int maxCount, Settings settings) {{
-        super(settings.maxCount(maxCount)
+        super((repairIngredientId == null ? settings
+                : settings.repairable(Registries.ITEM.get(Identifier.of(repairIngredientId))))
+                .maxCount(maxCount)
                 .maxDamage(durability)
-                .enchantability(enchantability)
-                .repairIngredient(repairIngredientId == null ? Ingredient.ofItems()
-                        : Ingredient.ofItems(Registries.ITEM.get(Identifier.of(repairIngredientId))))
+                .enchantable(enchantability)
                 .attributeModifiers(AttributeModifiersComponent.builder()
                         .add(EntityAttributes.ATTACK_DAMAGE,
                                 new EntityAttributeModifier(ATTACK_DAMAGE_MODIFIER_ID, attackDamage, EntityAttributeModifier.Operation.ADD_VALUE),
                                 AttributeModifierSlot.MAINHAND)
-                        .build())
-        );
+                        .build()));
         this.miningSpeedMultiplier = miningSpeedMultiplier;
         this.miningLevel = miningLevel;
     }}

--- a/fabricpy/modconfig.py
+++ b/fabricpy/modconfig.py
@@ -752,8 +752,10 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.recipe.Ingredient;
 import net.minecraft.registry.Registries;
 import net.minecraft.util.Identifier;
+import java.util.UUID;
 
 public class CustomToolItem extends Item {{
+    private static final UUID ATTACK_DAMAGE_MODIFIER_ID = UUID.fromString("fa233e1c-4180-4865-b01b-bcde54c9e5ad");
     private final float miningSpeedMultiplier;
     private final float attackDamage;
     private final int miningLevel;
@@ -769,12 +771,12 @@ public class CustomToolItem extends Item {{
         this.attackDamage = attackDamage;
         this.miningLevel = miningLevel;
         this.enchantability = enchantability;
-        this.repairIngredient = repairIngredientId == null ? Ingredient.empty()
+        this.repairIngredient = repairIngredientId == null ? Ingredient.EMPTY
                 : Ingredient.ofItems(Registries.ITEM.get(Identifier.of(repairIngredientId)));
         ImmutableMultimap.Builder<EntityAttribute, EntityAttributeModifier> builder = ImmutableMultimap.builder();
-        builder.put(EntityAttributes.GENERIC_ATTACK_DAMAGE,
+        builder.put(EntityAttributes.ATTACK_DAMAGE,
                 new EntityAttributeModifier(ATTACK_DAMAGE_MODIFIER_ID, \"Tool modifier\",
-                        attackDamage, EntityAttributeModifier.Operation.ADDITION));
+                        attackDamage, EntityAttributeModifier.Operation.ADD_VALUE));
         this.attributeModifiers = builder.build();
     }}
 
@@ -795,9 +797,9 @@ public class CustomToolItem extends Item {{
 
     @Override
     public Multimap<EntityAttribute, EntityAttributeModifier> getAttributeModifiers(
-            EquipmentSlot slot, ItemStack stack) {{
+            ItemStack stack, EquipmentSlot slot) {{
         return slot == EquipmentSlot.MAINHAND ? this.attributeModifiers
-                : super.getAttributeModifiers(slot, stack);
+                : super.getAttributeModifiers(stack, slot);
     }}
 }}
 """

--- a/fabricpy/modconfig.py
+++ b/fabricpy/modconfig.py
@@ -740,10 +740,9 @@ public class CustomItem extends Item {{
 
         return f"""package {pkg};
 
-import com.google.common.collect.ImmutableMultimap;
-import com.google.common.collect.Multimap;
 import net.minecraft.block.BlockState;
-import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.component.type.AttributeModifiersComponent;
+import net.minecraft.entity.attribute.AttributeModifierSlot;
 import net.minecraft.entity.attribute.EntityAttribute;
 import net.minecraft.entity.attribute.EntityAttributeModifier;
 import net.minecraft.entity.attribute.EntityAttributes;
@@ -752,54 +751,33 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.recipe.Ingredient;
 import net.minecraft.registry.Registries;
 import net.minecraft.util.Identifier;
-import java.util.UUID;
 
 public class CustomToolItem extends Item {{
-    private static final UUID ATTACK_DAMAGE_MODIFIER_ID = UUID.fromString("fa233e1c-4180-4865-b01b-bcde54c9e5ad");
+    private static final Identifier ATTACK_DAMAGE_MODIFIER_ID = Identifier.of("fabricpy", "tool_damage");
     private final float miningSpeedMultiplier;
-    private final float attackDamage;
     private final int miningLevel;
-    private final int enchantability;
-    private final Ingredient repairIngredient;
-    private final Multimap<EntityAttribute, EntityAttributeModifier> attributeModifiers;
 
     public CustomToolItem(int durability, float miningSpeedMultiplier, float attackDamage,
             int miningLevel, int enchantability, String repairIngredientId,
             int maxCount, Settings settings) {{
-        super(settings.maxCount(maxCount).maxDamage(durability));
+        super(settings.maxCount(maxCount)
+                .maxDamage(durability)
+                .enchantability(enchantability)
+                .repairIngredient(repairIngredientId == null ? Ingredient.ofItems()
+                        : Ingredient.ofItems(Registries.ITEM.get(Identifier.of(repairIngredientId))))
+                .attributeModifiers(AttributeModifiersComponent.builder()
+                        .add(EntityAttributes.ATTACK_DAMAGE,
+                                new EntityAttributeModifier(ATTACK_DAMAGE_MODIFIER_ID, attackDamage, EntityAttributeModifier.Operation.ADD_VALUE),
+                                AttributeModifierSlot.MAINHAND)
+                        .build())
+        );
         this.miningSpeedMultiplier = miningSpeedMultiplier;
-        this.attackDamage = attackDamage;
         this.miningLevel = miningLevel;
-        this.enchantability = enchantability;
-        this.repairIngredient = repairIngredientId == null ? Ingredient.EMPTY
-                : Ingredient.ofItems(Registries.ITEM.get(Identifier.of(repairIngredientId)));
-        ImmutableMultimap.Builder<EntityAttribute, EntityAttributeModifier> builder = ImmutableMultimap.builder();
-        builder.put(EntityAttributes.ATTACK_DAMAGE,
-                new EntityAttributeModifier(ATTACK_DAMAGE_MODIFIER_ID, \"Tool modifier\",
-                        attackDamage, EntityAttributeModifier.Operation.ADD_VALUE));
-        this.attributeModifiers = builder.build();
     }}
 
     @Override
-    public float getMiningSpeedMultiplier(ItemStack stack, BlockState state) {{
+    public float getMiningSpeed(ItemStack stack, BlockState state) {{
         return this.miningSpeedMultiplier;
-    }}
-
-    @Override
-    public int getEnchantability() {{
-        return this.enchantability;
-    }}
-
-    @Override
-    public boolean canRepair(ItemStack stack, ItemStack ingredient) {{
-        return this.repairIngredient.test(ingredient);
-    }}
-
-    @Override
-    public Multimap<EntityAttribute, EntityAttributeModifier> getAttributeModifiers(
-            ItemStack stack, EquipmentSlot slot) {{
-        return slot == EquipmentSlot.MAINHAND ? this.attributeModifiers
-                : super.getAttributeModifiers(stack, slot);
     }}
 }}
 """

--- a/fabricpy/modconfig.py
+++ b/fabricpy/modconfig.py
@@ -31,6 +31,7 @@ from typing import Dict, List, Set
 from .fooditem import FoodItem
 from .itemgroup import ItemGroup
 from .recipejson import RecipeJson
+from .toolitem import ToolItem
 
 
 # --------------------------------------------------------------------- #
@@ -566,6 +567,13 @@ class ModConfig:
         ) as fh:
             fh.write(self._custom_item_src(package_path))
 
+        # Generate CustomToolItem.java if any ToolItem is registered
+        if any(isinstance(i, ToolItem) for i in self.registered_items):
+            with open(
+                os.path.join(pkg_dir, "CustomToolItem.java"), "w", encoding="utf-8"
+            ) as fh:
+                fh.write(self._custom_tool_item_src(package_path))
+
     def _tutorial_items_src(self, pkg: str) -> str:
         """Generate Java source code for the TutorialItems class.
 
@@ -588,6 +596,7 @@ class ModConfig:
                 )
         """
         has_food = any(isinstance(i, FoodItem) for i in self.registered_items)
+        has_tool = any(isinstance(i, ToolItem) for i in self.registered_items)
         has_vanila = any(
             isinstance(getattr(i, "item_group", None), str)
             for i in self.registered_items
@@ -603,6 +612,8 @@ class ModConfig:
         L.append("import net.minecraft.registry.RegistryKey;")
         L.append("import net.minecraft.registry.RegistryKeys;")
         L.append("import net.minecraft.registry.Registries;")
+        if has_tool:
+            L.append(f"import {pkg}.CustomToolItem;")
         if has_vanila:
             L.append("import net.fabricmc.fabric.api.itemgroup.v1.ItemGroupEvents;")
             L.append("import net.minecraft.item.ItemGroups;")
@@ -625,6 +636,19 @@ class ModConfig:
                     f".maxCount({itm.max_stack_size})"
                 )
                 factory = "Item::new"
+            elif isinstance(itm, ToolItem):
+                settings = "new Item.Settings()"
+                repair = (
+                    "null"
+                    if itm.repair_ingredient is None
+                    else f'"{itm.repair_ingredient}"'
+                )
+                factory = (
+                    "s -> new CustomToolItem("
+                    f"{itm.durability}, {itm.mining_speed_multiplier}f, "
+                    f"{itm.attack_damage}f, {itm.mining_level}, {itm.enchantability}, "
+                    f"{repair}, {itm.max_stack_size}, s)"
+                )
             else:
                 settings = f"new Item.Settings().maxCount({itm.max_stack_size})"
                 factory = "CustomItem::new"
@@ -697,6 +721,83 @@ public class CustomItem extends Item {{
                     SoundEvents.BLOCK_WOOL_BREAK, SoundCategory.PLAYERS, 1F, 1F);
         }}
         return ActionResult.SUCCESS;
+    }}
+}}
+"""
+
+    def _custom_tool_item_src(self, pkg: str) -> str:
+        """Generate Java source code for the CustomToolItem class.
+
+        The generated class exposes tool-specific properties like durability,
+        mining speed, attack damage, enchantability and repair handling.
+
+        Args:
+            pkg (str): The Java package name for the generated class.
+
+        Returns:
+            str: Complete Java source for the CustomToolItem class.
+        """
+
+        return f"""package {pkg};
+
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.EquipmentSlot;
+import net.minecraft.entity.attribute.EntityAttribute;
+import net.minecraft.entity.attribute.EntityAttributeModifier;
+import net.minecraft.entity.attribute.EntityAttributes;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.recipe.Ingredient;
+import net.minecraft.registry.Registries;
+import net.minecraft.util.Identifier;
+
+public class CustomToolItem extends Item {{
+    private final float miningSpeedMultiplier;
+    private final float attackDamage;
+    private final int miningLevel;
+    private final int enchantability;
+    private final Ingredient repairIngredient;
+    private final Multimap<EntityAttribute, EntityAttributeModifier> attributeModifiers;
+
+    public CustomToolItem(int durability, float miningSpeedMultiplier, float attackDamage,
+            int miningLevel, int enchantability, String repairIngredientId,
+            int maxCount, Settings settings) {{
+        super(settings.maxCount(maxCount).maxDamage(durability));
+        this.miningSpeedMultiplier = miningSpeedMultiplier;
+        this.attackDamage = attackDamage;
+        this.miningLevel = miningLevel;
+        this.enchantability = enchantability;
+        this.repairIngredient = repairIngredientId == null ? Ingredient.empty()
+                : Ingredient.ofItems(Registries.ITEM.get(Identifier.of(repairIngredientId)));
+        ImmutableMultimap.Builder<EntityAttribute, EntityAttributeModifier> builder = ImmutableMultimap.builder();
+        builder.put(EntityAttributes.GENERIC_ATTACK_DAMAGE,
+                new EntityAttributeModifier(ATTACK_DAMAGE_MODIFIER_ID, \"Tool modifier\",
+                        attackDamage, EntityAttributeModifier.Operation.ADDITION));
+        this.attributeModifiers = builder.build();
+    }}
+
+    @Override
+    public float getMiningSpeedMultiplier(ItemStack stack, BlockState state) {{
+        return this.miningSpeedMultiplier;
+    }}
+
+    @Override
+    public int getEnchantability() {{
+        return this.enchantability;
+    }}
+
+    @Override
+    public boolean canRepair(ItemStack stack, ItemStack ingredient) {{
+        return this.repairIngredient.test(ingredient);
+    }}
+
+    @Override
+    public Multimap<EntityAttribute, EntityAttributeModifier> getAttributeModifiers(
+            EquipmentSlot slot, ItemStack stack) {{
+        return slot == EquipmentSlot.MAINHAND ? this.attributeModifiers
+                : super.getAttributeModifiers(slot, stack);
     }}
 }}
 """

--- a/fabricpy/toolitem.py
+++ b/fabricpy/toolitem.py
@@ -1,0 +1,96 @@
+# fabricpy/toolitem.py
+"""Tool item registration and definition for Fabric mods.
+
+This module provides the ToolItem class, which extends the base Item class
+with tool-specific properties such as durability and mining characteristics.
+"""
+
+from .item import Item
+
+
+class ToolItem(Item):
+    """Represents a tool item in a Fabric mod.
+
+    ToolItem extends the base :class:`~fabricpy.item.Item` class to add
+    properties relevant to tools and weapons, including durability,
+    mining speed, attack damage, mining level, enchantability and a
+    repair ingredient.
+
+    Args:
+        id: The registry identifier for the tool item (e.g.,
+            ``"mymod:obsidian_pickaxe"``). If ``None``, must be set
+            before compilation.
+        name: The display name for the tool item shown in-game. If
+            ``None``, must be set before compilation.
+        max_stack_size: Maximum number of items that can be stacked
+            together. Defaults to ``1`` for tools.
+        texture_path: Path to the item's texture file relative to mod
+            resources. If ``None``, a default texture will be used.
+        durability: Number of uses before the tool breaks. Defaults to ``0``.
+        mining_speed_multiplier: Speed multiplier when mining blocks.
+            Defaults to ``1.0``.
+        attack_damage: Damage dealt when used as a weapon. Defaults to ``1.0``.
+        mining_level: Mining level of the tool. Defaults to ``0``.
+        enchantability: How easily the tool can receive enchantments.
+            Defaults to ``0``.
+        repair_ingredient: Item ID used to repair the tool. Defaults to ``None``.
+        recipe: Recipe definition for crafting this tool item. Can be a
+            :class:`~fabricpy.recipejson.RecipeJson` instance or ``None`` for
+            no recipe.
+        item_group: Creative tab to place this item in. Can be an
+            :class:`~fabricpy.itemgroup.ItemGroup` instance, a string constant
+            from :mod:`fabricpy.item_group`, or ``None``.
+
+    Attributes:
+        durability (int): Number of uses before the tool breaks.
+        mining_speed_multiplier (float): Speed multiplier when mining blocks.
+        attack_damage (float): Damage dealt when used as a weapon.
+        mining_level (int): Mining tier of the tool (e.g., 0 for wooden).
+        enchantability (int): Likelihood of receiving better enchantments.
+        repair_ingredient (str | None): Item ID used to repair the tool.
+
+    Example:
+        Creating a ruby pickaxe::
+
+            pickaxe = ToolItem(
+                id="mymod:ruby_pickaxe",
+                name="Ruby Pickaxe",
+                durability=500,
+                mining_speed_multiplier=8.0,
+                attack_damage=3.0,
+                mining_level=2,
+                enchantability=22,
+                repair_ingredient="minecraft:ruby",
+            )
+    """
+
+    def __init__(
+        self,
+        id: str | None = None,
+        name: str | None = None,
+        max_stack_size: int = 1,
+        texture_path: str | None = None,
+        durability: int = 0,
+        mining_speed_multiplier: float = 1.0,
+        attack_damage: float = 1.0,
+        mining_level: int = 0,
+        enchantability: int = 0,
+        repair_ingredient: str | None = None,
+        recipe: object | None = None,
+        item_group: object | str | None = None,
+    ):
+        """Initialize a new :class:`ToolItem` instance."""
+        super().__init__(
+            id=id,
+            name=name,
+            max_stack_size=max_stack_size,
+            texture_path=texture_path,
+            recipe=recipe,
+            item_group=item_group,
+        )
+        self.durability = durability
+        self.mining_speed_multiplier = mining_speed_multiplier
+        self.attack_damage = attack_damage
+        self.mining_level = mining_level
+        self.enchantability = enchantability
+        self.repair_ingredient = repair_ingredient

--- a/tests/README.md
+++ b/tests/README.md
@@ -7,7 +7,7 @@ This directory contains comprehensive unit tests for the fabricpy library, ensur
 The test suite is organized into the following modules:
 
 ### Core Component Tests
-- **`test_items.py`** - Tests for the `Item` and `FoodItem` classes
+- **`test_items.py`** - Tests for the `Item`, `FoodItem`, and `ToolItem` classes
 - **`test_blocks.py`** - Tests for the `Block` class
 - **`test_recipe.py`** - Tests for the `RecipeJson` class
 - **`test_itemgroup.py`** - Tests for the `ItemGroup` class

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -8,7 +8,7 @@ import shutil
 import os
 
 import fabricpy
-from fabricpy import ModConfig, Item, FoodItem, Block, ItemGroup, RecipeJson, item_group
+from fabricpy import ModConfig, Item, FoodItem, Block, ItemGroup, RecipeJson, ToolItem, item_group
 
 
 class TestFabricPyIntegration(unittest.TestCase):
@@ -70,12 +70,18 @@ class TestFabricPyIntegration(unittest.TestCase):
             }
         })
         
-        advanced_tool = Item(
+        advanced_tool = ToolItem(
             id="integration_test:advanced_tool",
             name="Advanced Integration Tool",
             max_stack_size=1,
             recipe=advanced_recipe,
-            item_group=tools_group
+            item_group=tools_group,
+            durability=500,
+            mining_speed_multiplier=8.0,
+            attack_damage=3.0,
+            mining_level=2,
+            enchantability=15,
+            repair_ingredient="minecraft:diamond",
         )
         
         # Food item with complex properties
@@ -424,6 +430,7 @@ class TestFabricPyIntegration(unittest.TestCase):
         self.assertTrue(hasattr(fabricpy, 'ModConfig'))
         self.assertTrue(hasattr(fabricpy, 'Item'))
         self.assertTrue(hasattr(fabricpy, 'FoodItem'))
+        self.assertTrue(hasattr(fabricpy, 'ToolItem'))
         self.assertTrue(hasattr(fabricpy, 'Block'))
         self.assertTrue(hasattr(fabricpy, 'ItemGroup'))
         self.assertTrue(hasattr(fabricpy, 'RecipeJson'))

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -7,6 +7,7 @@ import unittest
 import fabricpy
 from fabricpy.item import Item
 from fabricpy.fooditem import FoodItem
+from fabricpy.toolitem import ToolItem
 from fabricpy.recipejson import RecipeJson
 from fabricpy import item_group
 
@@ -184,6 +185,68 @@ class TestFoodItem(unittest.TestCase):
         
         self.assertEqual(bread.recipe, recipe)
         self.assertEqual(bread.nutrition, 5)
+
+
+class TestToolItem(unittest.TestCase):
+    """Test the ToolItem class."""
+
+    def test_tool_item_creation_basic(self):
+        """Test creating a basic tool item."""
+        tool = ToolItem(
+            id="testmod:basic_tool",
+            name="Basic Tool",
+            durability=250,
+        )
+
+        self.assertEqual(tool.id, "testmod:basic_tool")
+        self.assertEqual(tool.name, "Basic Tool")
+        self.assertEqual(tool.max_stack_size, 1)
+        self.assertEqual(tool.durability, 250)
+        self.assertEqual(tool.mining_speed_multiplier, 1.0)
+        self.assertEqual(tool.attack_damage, 1.0)
+        self.assertEqual(tool.mining_level, 0)
+        self.assertEqual(tool.enchantability, 0)
+        self.assertIsNone(tool.repair_ingredient)
+
+    def test_tool_item_inheritance(self):
+        """Test that ToolItem properly inherits from Item."""
+        tool = ToolItem(
+            id="testmod:advanced_tool",
+            name="Advanced Tool",
+            max_stack_size=1,
+            texture_path="textures/items/adv_tool.png",
+            durability=500,
+            mining_speed_multiplier=8.0,
+            attack_damage=3.0,
+            mining_level=2,
+            enchantability=15,
+            repair_ingredient="minecraft:iron_ingot",
+            item_group=item_group.TOOLS,
+        )
+
+        # Test Item properties
+        self.assertEqual(tool.max_stack_size, 1)
+        self.assertEqual(tool.texture_path, "textures/items/adv_tool.png")
+        self.assertEqual(tool.item_group, item_group.TOOLS)
+
+        # Test ToolItem specific properties
+        self.assertEqual(tool.durability, 500)
+        self.assertEqual(tool.mining_speed_multiplier, 8.0)
+        self.assertEqual(tool.attack_damage, 3.0)
+        self.assertEqual(tool.mining_level, 2)
+        self.assertEqual(tool.enchantability, 15)
+        self.assertEqual(tool.repair_ingredient, "minecraft:iron_ingot")
+
+    def test_tool_item_default_values(self):
+        """ToolItem defaults to tool-specific settings."""
+        tool = ToolItem()
+        self.assertEqual(tool.max_stack_size, 1)
+        self.assertEqual(tool.durability, 0)
+        self.assertEqual(tool.mining_speed_multiplier, 1.0)
+        self.assertEqual(tool.attack_damage, 1.0)
+        self.assertEqual(tool.mining_level, 0)
+        self.assertEqual(tool.enchantability, 0)
+        self.assertIsNone(tool.repair_ingredient)
 
 
 if __name__ == '__main__':

--- a/tests/test_modconfig.py
+++ b/tests/test_modconfig.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 from fabricpy.modconfig import ModConfig
 from fabricpy.item import Item
 from fabricpy.fooditem import FoodItem
+from fabricpy.toolitem import ToolItem
 from fabricpy.block import Block
 from fabricpy.itemgroup import ItemGroup
 from fabricpy.recipejson import RecipeJson
@@ -875,10 +876,11 @@ class TestModConfigIntegration(unittest.TestCase):
         weapons_group = ItemGroup(id="test_weapons", name="Test Weapons")
         
         # Create multiple items in same group
-        sword = Item(
+        sword = ToolItem(
             id="grouped:test_sword",
             name="Test Sword",
-            item_group=weapons_group
+            item_group=weapons_group,
+            durability=250,
         )
         
         bow = Item(

--- a/tests/test_modconfig.py
+++ b/tests/test_modconfig.py
@@ -907,21 +907,25 @@ class TestModConfigIntegration(unittest.TestCase):
             content,
         )
 
-        self.assertTrue(
-            os.path.exists(
-                os.path.join(
-                    self.project_dir,
-                    "src",
-                    "main",
-                    "java",
-                    "com",
-                    "example",
-                    "tools",
-                    "items",
-                    "CustomToolItem.java",
-                )
-            )
+        custom_path = os.path.join(
+            self.project_dir,
+            "src",
+            "main",
+            "java",
+            "com",
+            "example",
+            "tools",
+            "items",
+            "CustomToolItem.java",
         )
+        self.assertTrue(os.path.exists(custom_path))
+
+        with open(custom_path, "r", encoding="utf-8") as fh:
+            custom_content = fh.read()
+
+        self.assertIn("Ingredient.EMPTY", custom_content)
+        self.assertIn("EntityAttributes.ATTACK_DAMAGE", custom_content)
+        self.assertIn("Operation.ADD_VALUE", custom_content)
 
     def test_multiple_items_same_group(self):
         """Test multiple items in the same custom group."""

--- a/tests/test_modconfig.py
+++ b/tests/test_modconfig.py
@@ -923,7 +923,7 @@ class TestModConfigIntegration(unittest.TestCase):
         with open(custom_path, "r", encoding="utf-8") as fh:
             custom_content = fh.read()
 
-        self.assertIn("Ingredient.EMPTY", custom_content)
+        self.assertIn("Ingredient.ofItems()", custom_content)
         self.assertIn("EntityAttributes.ATTACK_DAMAGE", custom_content)
         self.assertIn("Operation.ADD_VALUE", custom_content)
 

--- a/tests/test_modconfig.py
+++ b/tests/test_modconfig.py
@@ -862,6 +862,67 @@ class TestModConfigIntegration(unittest.TestCase):
         self.assertEqual(len(custom_groups), 1)
         self.assertIn(custom_group, custom_groups)
 
+    def test_tool_item_properties_applied(self):
+        """ToolItem settings are emitted into generated Java source."""
+        mod_config = ModConfig(
+            mod_id="tools",
+            name="Tools Mod",
+            version="1.0.0",
+            description="Test mod for tools",
+            authors=["Tester"],
+            project_dir=self.project_dir,
+        )
+
+        tool = ToolItem(
+            id="tools:ruby_pickaxe",
+            name="Ruby Pickaxe",
+            durability=500,
+            mining_speed_multiplier=8.0,
+            attack_damage=3.0,
+            mining_level=2,
+            enchantability=22,
+            repair_ingredient="minecraft:ruby",
+        )
+
+        mod_config.registerItem(tool)
+        mod_config.create_item_files(self.project_dir, "com.example.tools.items")
+
+        tut_path = os.path.join(
+            self.project_dir,
+            "src",
+            "main",
+            "java",
+            "com",
+            "example",
+            "tools",
+            "items",
+            "TutorialItems.java",
+        )
+
+        with open(tut_path, "r", encoding="utf-8") as fh:
+            content = fh.read()
+
+        self.assertIn(
+            "new CustomToolItem(500, 8.0f, 3.0f, 2, 22, \"minecraft:ruby\", 1, s)",
+            content,
+        )
+
+        self.assertTrue(
+            os.path.exists(
+                os.path.join(
+                    self.project_dir,
+                    "src",
+                    "main",
+                    "java",
+                    "com",
+                    "example",
+                    "tools",
+                    "items",
+                    "CustomToolItem.java",
+                )
+            )
+        )
+
     def test_multiple_items_same_group(self):
         """Test multiple items in the same custom group."""
         mod_config = ModConfig(

--- a/tests/test_modconfig.py
+++ b/tests/test_modconfig.py
@@ -923,9 +923,10 @@ class TestModConfigIntegration(unittest.TestCase):
         with open(custom_path, "r", encoding="utf-8") as fh:
             custom_content = fh.read()
 
-        self.assertIn("Ingredient.ofItems()", custom_content)
+        self.assertIn("settings.repairable(Registries.ITEM.get(Identifier.of(repairIngredientId)))", custom_content)
         self.assertIn("EntityAttributes.ATTACK_DAMAGE", custom_content)
         self.assertIn("Operation.ADD_VALUE", custom_content)
+        self.assertIn("AttributeModifierSlot.MAINHAND", custom_content)
 
     def test_multiple_items_same_group(self):
         """Test multiple items in the same custom group."""


### PR DESCRIPTION
## Summary
- document ToolItem attributes and include module in API docs
- add runnable ToolItem example and reference in README and docs
- expand ToolItem tests to cover default values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c76590fd4c832ab117997f6d321eda